### PR TITLE
多帧目标检测兼容 Jetson 平台

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
             },
             {
                 "name": "DISPLAY",
-                "value": "tl-Ai:10.0"
+                // "value": "tl-Ai:10.0"
             }
         ]
     },

--- a/src/gst-videorecognition/CMakeLists.txt
+++ b/src/gst-videorecognition/CMakeLists.txt
@@ -15,6 +15,7 @@ pkg_check_modules(GST REQUIRED
     gstreamer-base-1.0 
     gstreamer-video-1.0)
 find_package(OpenCV)
+include(CheckCXXSourceCompiles)
 
 
 # 4. 包含目录
@@ -45,6 +46,18 @@ add_library(gst_videorecognition SHARED ${SRCS} ${INCS})
 
 target_compile_definitions(gst_videorecognition PRIVATE 
     DS_VERSION="7.1.0")
+
+# 通过 __aarch64__ 宏判断 Jetson，使用 NVBUF_MEM_SURFACE_ARRAY
+check_cxx_source_compiles("
+#ifdef __aarch64__
+int main() { return 0; }
+#else
+#error Not aarch64
+#endif
+" HAS_AARCH64)
+if(HAS_AARCH64)
+    target_compile_definitions(gst_videorecognition PRIVATE USE_NVBUF_MEM_SURFACE_ARRAY=1)
+endif()
 
 MESSAGE(STATUS ${OpenCV_LIBS})
 


### PR DESCRIPTION
1. 检测 aarch64 架构，自动定义相关宏以支持 Jetson 平台。
2. 针对 Jetson 使用 NVBUF_MEM_SURFACE_ARRAY，提升内存兼容性与性能。
3. 注释掉 VSCode 设置中的 DISPLAY 变量，便于开发环境切换。