### PR TITLE
增加静止目标误检过滤功能

### DIFF
--- a/apps-common/includes/deepstream_tracker.h
+++ b/apps-common/includes/deepstream_tracker.h
@@ -41,6 +41,10 @@ typedef struct
   gchar* sub_batches;
   gint sub_batch_err_recovery_trial_cnt;
   gboolean enable_class_count_update; /* 启用单目标跟踪类别计数更新，默认1 */
+  gboolean enable_static_target_filter; /* 启用静止目标误检过滤 */
+  guint static_target_filter_frames; /* 判定为静止目标的连续帧数 */
+  gfloat static_target_filter_center_thresh; /* 中心点偏移阈值（像素） */
+  gfloat static_target_filter_size_thresh; /* 框尺寸变化阈值（比例） */
 } NvDsTrackerConfig;
 
 typedef struct

--- a/apps-common/src/deepstream-yaml/deepstream_tracker_yaml.cpp
+++ b/apps-common/src/deepstream-yaml/deepstream_tracker_yaml.cpp
@@ -33,6 +33,10 @@ parse_tracker_yaml (NvDsTrackerConfig *config, gchar *cfg_file_path)
   config->user_meta_pool_size = 32;
   config->sub_batches = {};
   config->sub_batch_err_recovery_trial_cnt = 0;
+  config->enable_static_target_filter = FALSE;
+  config->static_target_filter_frames = 30;
+  config->static_target_filter_center_thresh = 5.0f;
+  config->static_target_filter_size_thresh = 0.05f;
 
   for(YAML::const_iterator itr = configyml["tracker"].begin();
      itr != configyml["tracker"].end(); ++itr)
@@ -99,6 +103,14 @@ parse_tracker_yaml (NvDsTrackerConfig *config, gchar *cfg_file_path)
       std::strncpy (config->sub_batches, temp.c_str(), temp.size());
     } else if(paramKey == "sub-batch-err-recovery-trial-cnt"){
       config->sub_batch_err_recovery_trial_cnt =  itr->second.as<gint>();
+    } else if(paramKey == "static-target-filter"){
+      config->enable_static_target_filter = itr->second.as<gboolean>();
+    } else if(paramKey == "static-target-filter-frames"){
+      config->static_target_filter_frames = itr->second.as<guint>();
+    } else if(paramKey == "static-target-filter-center-threshold"){
+      config->static_target_filter_center_thresh = itr->second.as<gfloat>();
+    } else if(paramKey == "static-target-filter-size-threshold"){
+      config->static_target_filter_size_thresh = itr->second.as<gfloat>();
     } else {
       cout << "Unknown key " << paramKey << " for tracker" << endl;
     }

--- a/apps-common/src/deepstream_config_file_parser.c
+++ b/apps-common/src/deepstream_config_file_parser.c
@@ -143,6 +143,10 @@ GST_DEBUG_CATEGORY(APP_CFG_PARSER_CAT);
 #define CONFIG_GROUP_TRACKER_SUB_BATCHES "sub-batches"
 #define CONFIG_GROUP_TRACKER_SUB_BATCH_ERR_RECOVERY_TRIAL_CNT "sub-batch-err-recovery-trial-cnt"
 #define CONFIG_GROUP_TRACKER_ENABLE_CLASS_COUNT_UPDATE "enable-class-count-update"
+#define CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER "static-target-filter"
+#define CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_FRAMES "static-target-filter-frames"
+#define CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_CENTER_THRESH "static-target-filter-center-threshold"
+#define CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_SIZE_THRESH "static-target-filter-size-threshold"
 
 #define CONFIG_GROUP_SINK_TYPE "type"
 #define CONFIG_GROUP_SINK_WIDTH "width"
@@ -2093,6 +2097,10 @@ parse_tracker(NvDsTrackerConfig *config, GKeyFile *key_file,
     config->sub_batches = NULL;
     config->sub_batch_err_recovery_trial_cnt = 0;
     config->enable_class_count_update = TRUE; /* 默认启用 */
+    config->enable_static_target_filter = FALSE;
+    config->static_target_filter_frames = 30;
+    config->static_target_filter_center_thresh = 5.0f;
+    config->static_target_filter_size_thresh = 0.05f;
 
     for (key = keys; *key; key++)
     {
@@ -2239,6 +2247,34 @@ parse_tracker(NvDsTrackerConfig *config, GKeyFile *key_file,
             config->enable_class_count_update =
                 g_key_file_get_integer(key_file, CONFIG_GROUP_TRACKER,
                                        CONFIG_GROUP_TRACKER_ENABLE_CLASS_COUNT_UPDATE, &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER))
+        {
+            config->enable_static_target_filter =
+                g_key_file_get_integer(key_file, CONFIG_GROUP_TRACKER,
+                                       CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER, &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_FRAMES))
+        {
+            config->static_target_filter_frames =
+                g_key_file_get_integer(key_file, CONFIG_GROUP_TRACKER,
+                                       CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_FRAMES, &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_CENTER_THRESH))
+        {
+            config->static_target_filter_center_thresh =
+                g_key_file_get_double(key_file, CONFIG_GROUP_TRACKER,
+                                      CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_CENTER_THRESH, &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_SIZE_THRESH))
+        {
+            config->static_target_filter_size_thresh =
+                g_key_file_get_double(key_file, CONFIG_GROUP_TRACKER,
+                                      CONFIG_GROUP_TRACKER_STATIC_TARGET_FILTER_SIZE_THRESH, &error);
             CHECK_ERROR(error);
         }
         else

--- a/src/deepstream-app/configs/yml/app_config.yml
+++ b/src/deepstream-app/configs/yml/app_config.yml
@@ -35,6 +35,14 @@ tracker:
   ll-config-file: /opt/nvidia/deepstream/deepstream/sot_plugin/config/config_sot.yml
   gpu-id: 0
   display-tracking-id: 1
+  # TODO: 未测试。静止目标误检过滤开关（仅在 tracker 启用时生效）
+  static-target-filter: 0
+  # 连续帧数达到该值且目标稳定，则认为是静止误检目标
+  static-target-filter-frames: 30
+  # 目标中心点最大允许偏移（像素）
+  static-target-filter-center-threshold: 5.0
+  # 目标框尺寸变化阈值（比例，例如 0.05 表示 5%）
+  static-target-filter-size-threshold: 0.05
 
 videorecognition:
   enable: 1
@@ -45,7 +53,7 @@ videorecognition:
   processing-height: 64
   model-clip-length: 32
   sampling-rate: 5
-  trt-engine-file: /opt/nvidia/deepstream/deepstream/deepstream-app-custom/gst-videorecognition/models/x3d_v7_4cls_fp32.engine
+  trt-engine-file: /opt/nvidia/deepstream/deepstream/deepstream-app-custom/gst-videorecognition/models/x3d_v7_4cls_fp16.engine
   labels-file: /opt/nvidia/deepstream/deepstream/deepstream-app-custom/configs/cls_labels.txt
 
 sink0:

--- a/src/deepstream-app/deepstream_app.h
+++ b/src/deepstream-app/deepstream_app.h
@@ -175,6 +175,23 @@ extern "C"
         guint64 timestamp;
     } CustomMessageData;
 
+    typedef struct
+    {
+        gboolean active;
+        gboolean has_last;
+        guint64 last_object_id;
+        guint64 static_object_id;
+        guint   consecutive_count;
+        gfloat  last_cx;
+        gfloat  last_cy;
+        gfloat  last_w;
+        gfloat  last_h;
+        gfloat  static_cx;
+        gfloat  static_cy;
+        gfloat  static_w;
+        gfloat  static_h;
+    } StaticTargetFilterState;
+
     struct _AppCtx
     {
         gboolean version;
@@ -245,6 +262,9 @@ extern "C"
     GstClockTime tracking_start_time;        /* 当前目标开始连续跟踪的时间戳（纳秒） */
     guint64      last_tracked_object_id;     /* 上一次跟踪的目标ID */
     gboolean     is_tracking_continuous;     /* 是否正在连续跟踪同一目标 */
+
+    /* 静止目标误检过滤状态（按 source 维护） */
+    StaticTargetFilterState static_target_filter_states[MAX_SOURCE_BINS];
     };
 
     /**


### PR DESCRIPTION
1. 新增静止目标误检过滤相关配置项，支持自定义连续帧数、中心点偏移和尺寸变化阈值
2. 配置文件与解析逻辑均已更新，默认关闭静止目标过滤
3. 实现静止目标状态管理与过滤逻辑，按 source 独立维护过滤状态
4. 静止目标满足条件时自动从检测结果中过滤，减少误检干扰