### PR TITLE
cuav: improve pending visible focal confirmation with progress detection and timeout

### DIFF
--- a/apps-common/includes/deepstream_cuav_control.h
+++ b/apps-common/includes/deepstream_cuav_control.h
@@ -60,6 +60,8 @@ typedef struct
     gdouble servo_effect_threshold_h; /* 水平伺服生效判定阈值 */
     gdouble servo_effect_threshold_v; /* 垂直伺服生效判定阈值 */
     guint state_stale_timeout_ms; /* 设备状态新鲜度超时 */
+    guint pending_focal_timeout_ms; /* 可见光焦距pending确认超时（毫秒） */
+    gdouble pending_focal_progress_epsilon; /* 可见光焦距pending方向性进展阈值 */
     gboolean corner_zoom_cycle_enable; /* 是否启用四角伺服循环测试 */
     guint corner_cycle_count; /* 单轮四角循环次数 */
     guint sequence_repeat_count; /* 整套四角流程重复次数 */

--- a/apps-common/src/deepstream_config_file_parser.c
+++ b/apps-common/src/deepstream_config_file_parser.c
@@ -1502,6 +1502,8 @@ parse_cuav_control(NvDsCuavControlConfig *config, GKeyFile *key_file)
     config->servo_effect_threshold_h = 0.5;
     config->servo_effect_threshold_v = 0.3;
     config->state_stale_timeout_ms = 2000;
+    config->pending_focal_timeout_ms = 500;
+    config->pending_focal_progress_epsilon = 1.0;
     config->corner_zoom_cycle_enable = FALSE;
     config->corner_cycle_count = 1;
     config->sequence_repeat_count = 1;
@@ -1759,6 +1761,16 @@ parse_cuav_control(NvDsCuavControlConfig *config, GKeyFile *key_file)
         else if (!g_strcmp0(*key, "state-stale-timeout-ms"))
         {
             config->state_stale_timeout_ms = g_key_file_get_integer(key_file, CONFIG_GROUP_CUAV_CONTROL, "state-stale-timeout-ms", &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, "pending-focal-timeout-ms"))
+        {
+            config->pending_focal_timeout_ms = g_key_file_get_integer(key_file, CONFIG_GROUP_CUAV_CONTROL, "pending-focal-timeout-ms", &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, "pending-focal-progress-epsilon"))
+        {
+            config->pending_focal_progress_epsilon = g_key_file_get_double(key_file, CONFIG_GROUP_CUAV_CONTROL, "pending-focal-progress-epsilon", &error);
             CHECK_ERROR(error);
         }
         else if (!g_strcmp0(*key, "corner-zoom-cycle-enable"))
@@ -2874,6 +2886,8 @@ parse_sink(NvDsSinkSubBinConfig *config, GKeyFile *key_file, gchar *group,
     config->cuav_control_config.servo_effect_threshold_h = 0.5;
     config->cuav_control_config.servo_effect_threshold_v = 0.3;
     config->cuav_control_config.state_stale_timeout_ms = 2000;
+    config->cuav_control_config.pending_focal_timeout_ms = 500;
+    config->cuav_control_config.pending_focal_progress_epsilon = 1.0;
     config->cuav_control_config.startup_pt_focal = 20;
     config->cuav_control_config.startup_pt_focus = 100;
     config->cuav_control_config.lost_target_focal_min_hold_ms = 3000;
@@ -3457,6 +3471,18 @@ parse_sink(NvDsSinkSubBinConfig *config, GKeyFile *key_file, gchar *group,
         {
             config->cuav_control_config.state_stale_timeout_ms =
                 g_key_file_get_integer(key_file, group, "state-stale-timeout-ms", &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, "pending-focal-timeout-ms"))
+        {
+            config->cuav_control_config.pending_focal_timeout_ms =
+                g_key_file_get_integer(key_file, group, "pending-focal-timeout-ms", &error);
+            CHECK_ERROR(error);
+        }
+        else if (!g_strcmp0(*key, "pending-focal-progress-epsilon"))
+        {
+            config->cuav_control_config.pending_focal_progress_epsilon =
+                g_key_file_get_double(key_file, group, "pending-focal-progress-epsilon", &error);
             CHECK_ERROR(error);
         }
         else

--- a/src/deepstream-app/configs/yml/cuav_control_sink.yml
+++ b/src/deepstream-app/configs/yml/cuav_control_sink.yml
@@ -113,6 +113,12 @@ cuav-control:
   # 设备状态报文的新鲜度超时，单位毫秒。
   # 超过该时间未收到新状态时，会认为反馈过期。
   state-stale-timeout-ms: 2000
+  # 等待焦距反馈确认的超时，单位毫秒。
+  # 超时后会释放 pending，允许下发下一条变焦命令，避免链路卡死。
+  pending-focal-timeout-ms: 500
+  # 焦距反馈方向性进展阈值。
+  # 反馈朝目标方向变化达到该阈值时，视为本次pending命令已生效。
+  pending-focal-progress-epsilon: 1.0
   corner-zoom-cycle:
     # 是否启用“四角伺服”循环序列。
     # 0=关闭，1=开启；开启后会优先于 auto-track。

--- a/src/deepstream-app/deepstream_app.h
+++ b/src/deepstream-app/deepstream_app.h
@@ -297,6 +297,8 @@ typedef struct
     guint last_pt_focus;
     gboolean pending_pt_focal_valid; /* 已发送的绝对焦距目标值是否等待设备反馈确认 */
     gdouble pending_pt_focal;        /* 等待确认的焦距目标值 */
+    gdouble pending_pt_focal_base;   /* 发送该pending命令前的反馈焦距快照 */
+    gint64 pending_pt_focal_sent_us; /* pending焦距命令发送时间 */
     gboolean visible_initialized;
     gboolean lost_zoom_active;
     gint64 lost_zoom_start_us;

--- a/src/deepstream-app/deepstream_app_cuav_control.c
+++ b/src/deepstream-app/deepstream_app_cuav_control.c
@@ -23,8 +23,6 @@ GST_DEBUG_CATEGORY_EXTERN(NVDS_APP);
 #define DEFAULT_CUAV_TEST_MULTICAST_PORT 18003
 #define CUAV_FEEDBACK_STALE_USEC (2 * G_USEC_PER_SEC)
 #define CUAV_MOTION_CMD_MIN_SPACING_USEC (70 * 1000)
-#define CUAV_PENDING_FOCAL_TIMEOUT_USEC (500 * 1000)
-#define CUAV_PENDING_FOCAL_PROGRESS_EPSILON 1.0
 #define CUAV_FOCAL_REACHED_EPSILON 1.0
 
 typedef enum
@@ -124,8 +122,8 @@ static gboolean cuav_compute_average_velocity(const CuavAutoControlState *state,
                                               gdouble *vel_x,
                                               gdouble *vel_y);
 static gboolean cuav_pending_focal_resolved(const CuavAutoControlState *state,
+                                            const NvDsCuavControlConfig *control_config,
                                             const CuavFeedbackState *feedback_state,
-                                            guint stale_timeout_ms,
                                             gint64 now_us,
                                             gboolean *timed_out);
 static gboolean cuav_compute_servo_command(const NvDsCuavControlConfig *control_config,
@@ -991,13 +989,16 @@ cuav_compute_average_velocity(const CuavAutoControlState *state,
 
 static gboolean
 cuav_pending_focal_resolved(const CuavAutoControlState *state,
+                            const NvDsCuavControlConfig *control_config,
                             const CuavFeedbackState *feedback_state,
-                            guint stale_timeout_ms,
                             gint64 now_us,
                             gboolean *timed_out)
 {
     gdouble feedback_delta = 0.0;
     gdouble target_delta = 0.0;
+    guint stale_timeout_ms = 2000;
+    gint64 pending_timeout_us = 500 * 1000;
+    gdouble pending_progress_epsilon = 1.0;
 
     if (timed_out)
         *timed_out = FALSE;
@@ -1005,12 +1006,19 @@ cuav_pending_focal_resolved(const CuavAutoControlState *state,
     if (!state || !state->pending_pt_focal_valid)
         return TRUE;
 
+    if (control_config)
+    {
+        stale_timeout_ms = control_config->state_stale_timeout_ms;
+        pending_timeout_us = ((gint64)MAX(control_config->pending_focal_timeout_ms, 1U)) * 1000;
+        pending_progress_epsilon = MAX(control_config->pending_focal_progress_epsilon, 0.0);
+    }
+
     if (!feedback_state ||
         !cuav_feedback_is_fresh(feedback_state, stale_timeout_ms) ||
         feedback_state->pt_focal <= 0.0)
     {
         if (state->pending_pt_focal_sent_us > 0 &&
-            now_us - state->pending_pt_focal_sent_us >= CUAV_PENDING_FOCAL_TIMEOUT_USEC)
+            now_us - state->pending_pt_focal_sent_us >= pending_timeout_us)
         {
             if (timed_out)
                 *timed_out = TRUE;
@@ -1025,7 +1033,7 @@ cuav_pending_focal_resolved(const CuavAutoControlState *state,
     feedback_delta = feedback_state->pt_focal - state->pending_pt_focal_base;
     target_delta = state->pending_pt_focal - state->pending_pt_focal_base;
     if (fabs(target_delta) > CUAV_FOCAL_REACHED_EPSILON &&
-        fabs(feedback_delta) >= CUAV_PENDING_FOCAL_PROGRESS_EPSILON &&
+        fabs(feedback_delta) >= pending_progress_epsilon &&
         ((target_delta > 0.0 && feedback_delta > 0.0) ||
          (target_delta < 0.0 && feedback_delta < 0.0)))
     {
@@ -1033,7 +1041,7 @@ cuav_pending_focal_resolved(const CuavAutoControlState *state,
     }
 
     if (state->pending_pt_focal_sent_us > 0 &&
-        now_us - state->pending_pt_focal_sent_us >= CUAV_PENDING_FOCAL_TIMEOUT_USEC)
+        now_us - state->pending_pt_focal_sent_us >= pending_timeout_us)
     {
         if (timed_out)
             *timed_out = TRUE;
@@ -2397,8 +2405,8 @@ process_cuav_auto_control(AppCtx *appCtx, NvDsBatchMeta *batch_meta)
         {
             gboolean pending_timed_out = FALSE;
             if (cuav_pending_focal_resolved(&appCtx->cuav_auto_control_state,
+                                            control_config,
                                             &feedback_snapshot,
-                                            control_config->state_stale_timeout_ms,
                                             now_us,
                                             &pending_timed_out))
             {
@@ -2571,8 +2579,8 @@ process_cuav_auto_control(AppCtx *appCtx, NvDsBatchMeta *batch_meta)
     {
         gboolean pending_timed_out = FALSE;
         if (cuav_pending_focal_resolved(&appCtx->cuav_auto_control_state,
+                                        control_config,
                                         &feedback_snapshot,
-                                        control_config->state_stale_timeout_ms,
                                         now_us,
                                         &pending_timed_out))
         {

--- a/src/deepstream-app/deepstream_app_cuav_control.c
+++ b/src/deepstream-app/deepstream_app_cuav_control.c
@@ -23,6 +23,8 @@ GST_DEBUG_CATEGORY_EXTERN(NVDS_APP);
 #define DEFAULT_CUAV_TEST_MULTICAST_PORT 18003
 #define CUAV_FEEDBACK_STALE_USEC (2 * G_USEC_PER_SEC)
 #define CUAV_MOTION_CMD_MIN_SPACING_USEC (70 * 1000)
+#define CUAV_PENDING_FOCAL_TIMEOUT_USEC (500 * 1000)
+#define CUAV_PENDING_FOCAL_PROGRESS_EPSILON 1.0
 #define CUAV_FOCAL_REACHED_EPSILON 1.0
 
 typedef enum
@@ -121,6 +123,11 @@ static gboolean cuav_compute_average_velocity(const CuavAutoControlState *state,
                                               guint history_size,
                                               gdouble *vel_x,
                                               gdouble *vel_y);
+static gboolean cuav_pending_focal_resolved(const CuavAutoControlState *state,
+                                            const CuavFeedbackState *feedback_state,
+                                            guint stale_timeout_ms,
+                                            gint64 now_us,
+                                            gboolean *timed_out);
 static gboolean cuav_compute_servo_command(const NvDsCuavControlConfig *control_config,
                                            const CuavFeedbackState *feedback_state,
                                            const CuavAutoControlState *auto_state,
@@ -874,6 +881,8 @@ cuav_reset_auto_control_state(CuavAutoControlState *state, gboolean keep_last_co
     state->lost_zoom_hold_complete = FALSE;
     state->pending_pt_focal_valid = FALSE;
     state->pending_pt_focal = 0.0;
+    state->pending_pt_focal_base = 0.0;
+    state->pending_pt_focal_sent_us = 0;
     state->history_len = 0;
     state->history_next = 0;
     memset(state->history, 0, sizeof(state->history));
@@ -978,6 +987,60 @@ cuav_compute_average_velocity(const CuavAutoControlState *state,
     *vel_x = (last->err_x - first->err_x) / dt_sec;
     *vel_y = (last->err_y - first->err_y) / dt_sec;
     return TRUE;
+}
+
+static gboolean
+cuav_pending_focal_resolved(const CuavAutoControlState *state,
+                            const CuavFeedbackState *feedback_state,
+                            guint stale_timeout_ms,
+                            gint64 now_us,
+                            gboolean *timed_out)
+{
+    gdouble feedback_delta = 0.0;
+    gdouble target_delta = 0.0;
+
+    if (timed_out)
+        *timed_out = FALSE;
+
+    if (!state || !state->pending_pt_focal_valid)
+        return TRUE;
+
+    if (!feedback_state ||
+        !cuav_feedback_is_fresh(feedback_state, stale_timeout_ms) ||
+        feedback_state->pt_focal <= 0.0)
+    {
+        if (state->pending_pt_focal_sent_us > 0 &&
+            now_us - state->pending_pt_focal_sent_us >= CUAV_PENDING_FOCAL_TIMEOUT_USEC)
+        {
+            if (timed_out)
+                *timed_out = TRUE;
+            return TRUE;
+        }
+        return FALSE;
+    }
+
+    if (fabs(feedback_state->pt_focal - state->pending_pt_focal) <= CUAV_FOCAL_REACHED_EPSILON)
+        return TRUE;
+
+    feedback_delta = feedback_state->pt_focal - state->pending_pt_focal_base;
+    target_delta = state->pending_pt_focal - state->pending_pt_focal_base;
+    if (fabs(target_delta) > CUAV_FOCAL_REACHED_EPSILON &&
+        fabs(feedback_delta) >= CUAV_PENDING_FOCAL_PROGRESS_EPSILON &&
+        ((target_delta > 0.0 && feedback_delta > 0.0) ||
+         (target_delta < 0.0 && feedback_delta < 0.0)))
+    {
+        return TRUE;
+    }
+
+    if (state->pending_pt_focal_sent_us > 0 &&
+        now_us - state->pending_pt_focal_sent_us >= CUAV_PENDING_FOCAL_TIMEOUT_USEC)
+    {
+        if (timed_out)
+            *timed_out = TRUE;
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 /**
@@ -2330,16 +2393,24 @@ process_cuav_auto_control(AppCtx *appCtx, NvDsBatchMeta *batch_meta)
             cuav_reset_auto_control_state(&appCtx->cuav_auto_control_state, TRUE);
         }
         feedback_snapshot = appCtx->cuav_feedback_state;
-        if (appCtx->cuav_auto_control_state.pending_pt_focal_valid &&
-            cuav_feedback_is_fresh(&feedback_snapshot,
-                                   control_config->state_stale_timeout_ms) &&
-            fabs(feedback_snapshot.pt_focal -
-                 appCtx->cuav_auto_control_state.pending_pt_focal) <=
-                CUAV_FOCAL_REACHED_EPSILON)
+        if (appCtx->cuav_auto_control_state.pending_pt_focal_valid)
         {
-            appCtx->cuav_auto_control_state.pending_pt_focal_valid = FALSE;
-            appCtx->cuav_auto_control_state.last_pt_focal =
-                feedback_snapshot.pt_focal;
+            gboolean pending_timed_out = FALSE;
+            if (cuav_pending_focal_resolved(&appCtx->cuav_auto_control_state,
+                                            &feedback_snapshot,
+                                            control_config->state_stale_timeout_ms,
+                                            now_us,
+                                            &pending_timed_out))
+            {
+                appCtx->cuav_auto_control_state.pending_pt_focal_valid = FALSE;
+                appCtx->cuav_auto_control_state.pending_pt_focal = 0.0;
+                appCtx->cuav_auto_control_state.pending_pt_focal_base = 0.0;
+                appCtx->cuav_auto_control_state.pending_pt_focal_sent_us = 0;
+                if (feedback_snapshot.pt_focal > 0.0)
+                    appCtx->cuav_auto_control_state.last_pt_focal = feedback_snapshot.pt_focal;
+                if (pending_timed_out && debug_enabled)
+                    g_print("[cuav][control][auto] pending focal confirmation timeout, allow next command\n");
+            }
         }
         state_snapshot = appCtx->cuav_auto_control_state;
         g_mutex_unlock(&appCtx->cuav_control_lock);
@@ -2498,20 +2569,26 @@ process_cuav_auto_control(AppCtx *appCtx, NvDsBatchMeta *batch_meta)
     feedback_snapshot = appCtx->cuav_feedback_state;
     if (appCtx->cuav_auto_control_state.pending_pt_focal_valid)
     {
-        if (cuav_feedback_is_fresh(&feedback_snapshot,
-                                   control_config->state_stale_timeout_ms) &&
-            fabs(feedback_snapshot.pt_focal -
-                 appCtx->cuav_auto_control_state.pending_pt_focal) <=
-                CUAV_FOCAL_REACHED_EPSILON)
+        gboolean pending_timed_out = FALSE;
+        if (cuav_pending_focal_resolved(&appCtx->cuav_auto_control_state,
+                                        &feedback_snapshot,
+                                        control_config->state_stale_timeout_ms,
+                                        now_us,
+                                        &pending_timed_out))
         {
+            gdouble pending_target = appCtx->cuav_auto_control_state.pending_pt_focal;
             appCtx->cuav_auto_control_state.pending_pt_focal_valid = FALSE;
-            appCtx->cuav_auto_control_state.last_pt_focal =
-                feedback_snapshot.pt_focal;
+            appCtx->cuav_auto_control_state.pending_pt_focal = 0.0;
+            appCtx->cuav_auto_control_state.pending_pt_focal_base = 0.0;
+            appCtx->cuav_auto_control_state.pending_pt_focal_sent_us = 0;
+            if (feedback_snapshot.pt_focal > 0.0)
+                appCtx->cuav_auto_control_state.last_pt_focal = feedback_snapshot.pt_focal;
             if (debug_enabled)
             {
-                g_print("[cuav][control][auto] focal confirmed target=%.1f feedback=%.1f\n",
-                        appCtx->cuav_auto_control_state.pending_pt_focal,
-                        feedback_snapshot.pt_focal);
+                g_print("[cuav][control][auto] focal confirmed/advanced target=%.1f feedback=%.1f%s\n",
+                        pending_target,
+                        feedback_snapshot.pt_focal,
+                        pending_timed_out ? " timeout" : "");
             }
         }
         else
@@ -2532,6 +2609,8 @@ process_cuav_auto_control(AppCtx *appCtx, NvDsBatchMeta *batch_meta)
                                       &state_snapshot);
         appCtx->cuav_auto_control_state.pending_pt_focal_valid = FALSE;
         appCtx->cuav_auto_control_state.pending_pt_focal = 0.0;
+        appCtx->cuav_auto_control_state.pending_pt_focal_base = 0.0;
+        appCtx->cuav_auto_control_state.pending_pt_focal_sent_us = 0;
         appCtx->cuav_auto_control_state.lost_zoom_active = FALSE;
         appCtx->cuav_auto_control_state.lost_zoom_start_us = 0;
         appCtx->cuav_auto_control_state.lost_zoom_hold_complete = FALSE;
@@ -2703,11 +2782,16 @@ process_cuav_auto_control(AppCtx *appCtx, NvDsBatchMeta *batch_meta)
             {
                 appCtx->cuav_auto_control_state.pending_pt_focal_valid = TRUE;
                 appCtx->cuav_auto_control_state.pending_pt_focal = pt_focal;
+                appCtx->cuav_auto_control_state.pending_pt_focal_base =
+                    cuav_get_current_pt_focal(control_config, &feedback_snapshot, &state_snapshot);
+                appCtx->cuav_auto_control_state.pending_pt_focal_sent_us = now_us;
             }
             else
             {
                 appCtx->cuav_auto_control_state.pending_pt_focal_valid = FALSE;
                 appCtx->cuav_auto_control_state.pending_pt_focal = 0.0;
+                appCtx->cuav_auto_control_state.pending_pt_focal_base = 0.0;
+                appCtx->cuav_auto_control_state.pending_pt_focal_sent_us = 0;
             }
             appCtx->cuav_auto_control_state.last_visible_send_us = now_us;
             appCtx->cuav_auto_control_state.visible_initialized = TRUE;


### PR DESCRIPTION
### Motivation

- Prevent stalled "pending" visible focal commands from blocking subsequent focus changes by detecting actual focal progress and applying a timeout fallback.

### Description

- Added state fields `pending_pt_focal_base` and `pending_pt_focal_sent_us` to `CuavAutoControlState` and initialized/cleared them in `cuav_reset_auto_control_state` and relevant code paths. 
- Introduced macros `CUAV_PENDING_FOCAL_TIMEOUT_USEC` and `CUAV_PENDING_FOCAL_PROGRESS_EPSILON` to control timeout and progress thresholds. 
- Implemented `cuav_pending_focal_resolved` helper to determine whether a pending focal target has been reached by exact match, by observed feedback progress in the expected direction, or by timeout. 
- Updated auto-control logic in `process_cuav_auto_control` to use the new helper for pending focal confirmation, set the pending base value and sent timestamp when issuing visible focal commands, and clear those fields when cancelling or on lost-target recovery; added a debug log when a pending focal is resolved due to timeout.

### Testing

- Built the project using `make` and confirmed the build succeeded. 
- Ran the existing automated test suite via `ctest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5260ab788328b30a1ac43bb42e01)